### PR TITLE
Changed shebang line to more standard env implementation.

### DIFF
--- a/bin/carapace
+++ b/bin/carapace
@@ -1,4 +1,4 @@
-#!/usr/local/bin/node
+#!/usr/bin/env node
 
 var path = require('path'),
     async = require('async'),

--- a/bin/carapace-client
+++ b/bin/carapace-client
@@ -1,4 +1,4 @@
-#!/usr/local/bin/node
+#!/usr/bin/env node
 
 var hookio = require('hook.io');
 var Hook = hookio.Hook;


### PR DESCRIPTION
Changed shebang line to more standard env implementation. This solves problems running Haibu on systems where node isn't installed in /usr/local/bin/node...
