### PR TITLE
Wrong use of `this` in nextTick function

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -167,7 +167,7 @@ module.exports = function overrideNet () {
           //
           // Generate a new socket of the same type since we cannot use an already bound one
           //
-          self.fd = socket(this.type);
+          self.fd = socket(self.type);
           self._doListen(desired, addr);
         }
         return;


### PR DESCRIPTION
Found a nasty bug in the net module. The code was using `this` instead of `self` in the nextTick function...

Hope it is possible to push this pull request soon?
