### PR TITLE
Command line arguments for wrapped scripts are not made available

### DIFF
--- a/bin/carapace
+++ b/bin/carapace
@@ -25,7 +25,7 @@ function onPluginError (info) {
 //
 // Setup the passthru arguments.
 //
-var passthru = carapace.cli.extract(null, argv);
+var passthru = carapace.cli.extract(null, script);
 
 //
 // Remark: Calling `carapace.listen()` with no

--- a/lib/carapace.js
+++ b/lib/carapace.js
@@ -153,6 +153,9 @@ carapace.use = function (plugins, callback) {
 // ### function run (script, argv, callback)
 // #### @script {string} Path to the script to run inside the carapace.
 // #### @argv {Array} Arguments to rewrite into process.argv
+// #### @override {Boolean} When true remove current process.argv and replace
+// with [script, argv]. If false remove all arguments that would be 
+// overwritten by the new [script, argv] 
 // #### @callback {function} Continuation to respond to when complete.
 // Runs the script in `argv[0]` with the rest of the arguments specified 
 // in `argv` by transparently rewriting the current `process.argv`.

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -43,11 +43,14 @@ exports.options = function (options, argv) {
   return hookio.cli.options(defaultOptions, argv).options(options);
 };
 
-exports.extract = function (options, argv) {
-  var parsed = exports.options(options, argv).argv,
-      file = parsed._[0];
-  
-  return process.argv.splice(process.argv.indexOf(file)).splice(1);
+exports.extract = function (options, script) {
+  // get current process arguments in clean array
+  var argv = [].concat(process.argv);
+  // if script is not given then get the first non option argument from process.argv
+  script = script || exports.options(options).argv._[0];
+
+  // remove everything upto and including the script
+  return argv.splice(argv.indexOf(script)+1);
 };
 
 exports.rewrite = function (script, argv, override) {
@@ -82,5 +85,5 @@ exports.rewrite = function (script, argv, override) {
 };
 
 exports.argv = function (argv) {
-  return  hookio.cli.options(defaultOptions, argv).argv;
+  return exports.options({}, argv).argv;
 };

--- a/test/fixtures/checkchildargs.js
+++ b/test/fixtures/checkchildargs.js
@@ -1,0 +1,7 @@
+/*
+ * Test client argument rewrite of haibu.carapace
+ *
+ */
+
+console.log('%j', process.argv);
+process.exit(0);

--- a/test/simple/child-argument-test.js
+++ b/test/simple/child-argument-test.js
@@ -1,0 +1,64 @@
+/*
+ * child-argument-test.js: Basic child argument rewrite tests
+ *
+ * (C) 2011 stolsma
+ * MIT LICENCE
+ *
+ */
+
+var assert = require('assert'),
+    path = require('path'),
+    spawn = require('child_process').spawn,
+    vows = require('vows'),
+    helper = require('../helper/macros.js'),
+    carapace = require('../../lib/carapace');
+
+var script = path.join(__dirname, '..', 'fixtures' ,'checkchildargs.js'),
+    IOPORT = 5060,
+    testPort = 8000,
+    checkargs = ['argument', '-a', 'aargument', '--test', 'testargument'];
+    argv = ['--hook-port', IOPORT, '--hook-name', 'carapace', script];
+
+vows.describe('carapace/simple/child-argument').addBatch({
+  "When using haibu-carapace": helper.assertListen(IOPORT, {
+    "spawning the checkchildargs.js script via the child carapace": {
+      topic: function () {
+        var that = this,
+            child,
+            result = {
+              arguments: '',
+              exitCode: -1
+            };
+        child = spawn(carapace.bin, argv.concat(checkargs));
+
+        child.stdout.on('data', function (data) {
+          result.arguments += data;
+        });
+
+        child.on('exit', function (code) {
+          result.exitCode = code;
+          // process all events before asserting
+          process.nextTick(function(){
+            that.callback(null, result, child);
+          });
+        });
+      },
+      "should exit": {
+        topic: function (info, child) {
+          this.callback(null, info, child);
+        },
+        "with the correct exit code": function (_, info, child) {
+          assert.equal(info.exitCode, 0);
+        },
+        "and correct client arguments": function (_, info, child) {
+          var childargs = JSON.parse(info.arguments);
+          // first two are reference to node and the script itself
+          var node = childargs.splice(0, 1);
+          var resultscript = childargs.splice(0, 1);
+          assert.equal(resultscript, script);
+          assert.deepEqual(childargs, checkargs);
+        }
+      }
+    }
+  })
+}).export(module);


### PR DESCRIPTION
When trying to send arguments to a, in haibu-carapace, wrapped script the command line arguments specifically meant for the wrapped script where not available in the `process.argv` of the wrapped script.

Included is a test script showing the deficiency and a fix for the bug.
