### PR TITLE
[v0.6] Make C++ addon v0.6-compatible

### DIFF
--- a/src/evref.cc
+++ b/src/evref.cc
@@ -1,16 +1,16 @@
-#include <ev.h>
+#include <uv.h>
 #include <v8.h>
 
 using namespace v8;
 
 Handle<Value> Unref(const Arguments &args) {
 	HandleScope scope;
-	ev_unref();
+	uv_unref(uv_default_loop());
 	scope.Close(Undefined());
 }
 Handle<Value> Ref(const Arguments &args) {
 	HandleScope scope;
-	ev_ref();
+	uv_ref(uv_default_loop());
 	scope.Close(Undefined());
 }
 


### PR DESCRIPTION
- include `uv.h` instead of `ev.h`
- use `uv_unref` and `uv_ref` with `uv_default_loop()` parameter (node
  uses default loop, as per
  http://nodejs.org/docs/v0.5.9/api/addons.html )

@bmeck Review?
