### PR TITLE
[refactor v0.6] Refactor `net` module

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -6,12 +6,7 @@
  */
 
 var net = require('net'),
-    binding = process.binding('net'),
     carapace = require('./carapace');
-
-var dummyFD = null,
-    socket = binding.socket,
-    listen = binding.listen;
 
 module.exports = function overrideNet() {
   //
@@ -44,17 +39,6 @@ module.exports = function overrideNet() {
     return port;
   }
 
-  //
-  // Helper function from node.js core for
-  // working with `dummyFD`
-  //
-  function getDummyFD() {
-    if (!dummyFD) {
-      try { dummyFD = socket('tcp') }
-      catch (e) { dummyFD = null }
-    }
-  }
-
 
   //
   // Internal mapping of server instances to
@@ -62,31 +46,17 @@ module.exports = function overrideNet() {
   //
   carapace.servers = {};
 
-  //
-  // Remark: Are we ever going to need this?
-  //
-  // carapace.on('proxy::list', function (done) {
-  //   done(carapace.proxy.ports);
-  // });
+  var _listen2 = net.Server.prototype._listen2;
+  net.Server.prototype._listen2 = function ourListen(address, port, addressType, desired) {
+    var self = this;
 
-  //
-  // Separate since net.Server uses a cached bind function
-  //
-  net.Server.prototype._doListen = function () {
-    var self = this,
-        desired = toPort(arguments[0]),
-        addr = arguments[1],
-        current,
-        actual,
-        err;
-
-    // Ensure we have a dummy fd for EMFILE conditions.
-    getDummyFD();
+    port = toPort(port);
+    desired || (desired = port);
 
     //
     // Always throw if our desired port was one that should always throw
     //
-    if (carapace.ports.throw.indexOf(desired) !== -1) {
+    if (carapace.ports.throw.indexOf(port) !== -1) {
       self.close();
       //
       // Build fake error
@@ -101,83 +71,101 @@ module.exports = function overrideNet() {
     // Since desired is not on a throwing port
     // we want to skip ports in both throw and ignore
     //
-    current = desired ? desired : nextPort(desired);
+    port || (port = nextPort(port));
 
-    for (;;) {
-      try {
-        binding.bind(self.fd, current, addr);
-        break;
-      }
-      catch (err) {
-        //
-        // Find the next port we are not supposed to throw up on or ignore
-        //
-        current = nextPort(current);
+    //
+    // We rely on `error` event to check if address it taken/available, however
+    // user may want to hook up to `error` in his application as well (and
+    // usually exit when it's emitted). This messes things up. Here we store
+    // `error` event listeners and remove them. They will be restored after we
+    // start listening or get an error which is not `EADDRINUSE`.
+    //
+    var errorListeners = self.listeners('error');
+    self.removeAllListeners('error');
 
-        //
-        // If this is not an `EADDRINUSE` error or the port is in
-        // `carapace.ports.throw` which should always throw an error,
-        // then throw the error.
-        //
-        if (err.code !== 'EADDRINUSE') {
-          self.close();
-          self.emit('error', err);
-          return;
-        }
-      }
-    }
-
-    actual = this.address().port;
-    if (!desired) {
-      desired = actual;
+    function restoreErrorListeners() {
+      errorListeners.forEach(function (listener) {
+        self.on('error', listener);
+      });
     }
 
     //
-    // Need to the listening in the nextTick so that people potentially have
-    // time to register 'listening' listeners.
+    // Problem with `listening` events is a bit different. We want to ensure
+    // that we first emit `carapace::port` and *then* the proper `listening`
+    // event (which can be consumed by user's app).
+    //
+    // (Also, not doing so breaks `net/net-multiple-servers-test` test.)
+    //
+    var listeningListeners = self.listeners('listening');
+    self.removeAllListeners('listening');
+
+    function restoreListeningListeners() {
+      listeningListeners.forEach(function (listener) {
+        self.on('listening', listener);
+      });
+    }
+
+    function onListen() {
+      //
+      // Yay, we made it! Lets restore `error` listeners and tell the world
+      // that we totally owned this port.
+      //
+
+      self.removeListener('error', onError);
+
+      restoreErrorListeners();
+      restoreListeningListeners();
+
+      //
+      // Store the server that has listened on the `desired` port
+      // on the carapace itself, indexed by port.
+      //
+      carapace.servers[desired] = self;
+
+      carapace.emit('carapace::port', {
+        id: carapace.id,
+        addr: address,
+        port: port,
+        desired: desired
+      });
+
+      process.nextTick(function () {
+        self.emit('listening');
+      });
+    }
+
+    function onError(err) {
+      //
+      // We failed to listen. Unless it's not EADDRINUSE lets try doing the
+      // same thing, just with next port.
+      //
+
+      self.removeListener('listening', onListen);
+
+      //
+      // We can safely restore these listeners here. We're going to call
+      // `ourFunction`, so they will be removed again anyway.
+      //
+      restoreErrorListeners();
+      restoreListeningListeners();
+
+      if (err.code !== 'EADDRINUSE') {
+        self.close();
+        return self.emit('error', err);
+      }
+
+      ourListen.call(self, address, nextPort(port), addressType, desired);
+    }
+
+    self.once('listening', onListen);
+    self.once('error', onError);
+
+    //
+    // Call original _listen2 function.
     //
     process.nextTick(function () {
-      //
-      // It could be that server.close() was called between the time the
-      // original listen command was issued and this. Bail if that's the case.
-      // See test/simple/test-net-eaddrinuse.js
-      //
-      if (typeof self.fd !== 'number') {
-        return;
-      }
-
-      try {
-        listen(self.fd, self._backlog || 128);
-
-        //
-        // Store the server that has listened on the `desired` port
-        // on the carapace itself, indexed by port.
-        //
-        carapace.servers[desired] = self;
-
-        carapace.emit('carapace::port', {
-          id: carapace.id,
-          addr: addr,
-          desired: desired,
-          port: actual
-        });
-      }
-      catch (err) {
-        if (err.code !== 'EADDRINUSE') {
-          self.close();
-          self.emit('error', err);
-        }
-        else {
-          //
-          // Generate a new socket of the same type since we cannot use an already bound one
-          //
-          self.fd = socket(self.type);
-          self._doListen(desired, addr);
-        }
-        return;
-      }
-
-      self._startWatcher();
+      _listen2.call(self, address, port, addressType);
     });
   };
 };
+


### PR DESCRIPTION
Changes:
- monkey-patch `_listen2` instead of `_doListen`
- get rid of `process.binding('net')`, it was removed
- remove part responsible for getting dummy file descriptor

Please note that this breaks compatibility with `node v0.4`. If we're going to take this patch, I would propose creating maintenance branch `v0.2`, merging this pull request into `master`, bumping `master`'s version to `v0.3.0` and moving on with development.
