### PR TITLE
Remove "carapace has wrapped" message

### DIFF
--- a/bin/carapace
+++ b/bin/carapace
@@ -67,7 +67,6 @@ function configure (next) {
 
 function runAndReport () {
   carapace.run(carapace.script, true, function () {
-    _send.call(process, 'carapace has wrapped: ' + carapace.script);
 
     function logArray (array, msg, delim) {
       return array && array.length


### PR DESCRIPTION
In the context of haibu and nodejitsu, the "carapace has wrapped" message is confusing and out-of-context. This commit simply removes the notification from haibu-carapace, since it appears to be for logging/debug purposes only.
