### PR TITLE
[fix test] Ports should be subsequent

### DIFF
--- a/lib/plugins/net.js
+++ b/lib/plugins/net.js
@@ -197,7 +197,7 @@ module.exports._listen2 = function overrideNet() {
         self.emit('error', err);
       }
       else {
-        ourListen.call(self, '0.0.0.0', 0, addressType, desired);
+        ourListen.call(self, '0.0.0.0', nextPort(port), addressType, desired);
       }
     }
 

--- a/test/net/net-multiple-servers-test.js
+++ b/test/net/net-multiple-servers-test.js
@@ -54,11 +54,13 @@ vows.describe('carapace/net/dolisten').addBatch({
           assert.equal(info.exitCode, 0);
         },
         "and 3x emit the `port` event with the correct port": function (_, info, child) {
-          var desired = testPort;
+          var desired = testPort,
+              port = desired;
               
           assert.equal(info.events.length, 3);
           info.events.forEach(function (event, index) {
             assert.equal(event.info.desired, desired);
+            assert.equal(event.info.port, port++);
           });
         }
       }


### PR DESCRIPTION
This (in most cases) provides consistency between `haibu` restarts.
