### PR TITLE
[fix] Allow the net override on 0.9.x

### DIFF
--- a/lib/plugins/net.js
+++ b/lib/plugins/net.js
@@ -217,4 +217,4 @@ module.exports._listen2 = function overrideNet() {
 // Setup the valid `nodeVersion` for all of the 
 // monkey patches to `require('net')`.
 //
-module.exports._listen2.nodeVersion = '0.5.x || 0.6.x || 0.7.x || 0.8.x';
+module.exports._listen2.nodeVersion = '0.5.x || 0.6.x || 0.7.x || 0.8.x || 0.9.x';


### PR DESCRIPTION
Tested on 0.9.3-pre with no problems.
