### PR TITLE
Windows fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,6 @@ node_modules/
 npm-debug.log
 config.json
 *.sw[op]
+.idea/
+
 

--- a/examples/spawner.js
+++ b/examples/spawner.js
@@ -15,6 +15,8 @@ carapace.use([
   carapace.plugins.chdir
 ], function () {
   carapace.chdir(path.join(__dirname, 'app'));
+  carapace.script = script;
+
   carapace.run(script, ['--port', scriptPort], function afterRun() {
     carapace.heartbeat(function () {
       carapace.on('heartbeat', function () {

--- a/lib/carapace.js
+++ b/lib/carapace.js
@@ -190,18 +190,27 @@ carapace.run = function (override, callback) {
 // #### @script {string} Path to the script to run inside the carapace
 //
 carapace.load = function (script) {
+  var name,
+    absolutePath = false;
+
   if (script[0] === '.') {
     throw new Error('Cannot load relative paths into carapace. Provide an absolute path');
   }
 
-  var name = path.basename(script, '.js');
+  name = path.basename(script, '.js');
 
   if (carapace.plugins[name]) {
     // if we already have the plugin,
     return carapace.plugins[name];
   }
 
-  if ('/' !== script[0]) {
+  if(process.platform === 'win32') {
+    absolutePath = script.match(/^[a-z]:/i) ? true : false;
+  } else {
+    absolutePath = '/' === script[0];
+  }
+
+  if (!absolutePath) {
     //
     // If it is not a relative or absolute path, make it absolute
     // from the current `process.cwd()`.

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -69,7 +69,15 @@ exports.rewrite = function (script, argv, override) {
     // If it is not a relative or absolute path, make it absolute
     // from the current `process.cwd()`.
     //
-    script = path.join(process.cwd(), script);
+    var absolutePath = false;
+
+    if(process.platform === 'win32') {
+      absolutePath = script.match(/^[a-z]:/i) ? true : false;
+    }
+
+    if(!absolutePath) {
+      script = path.join(process.cwd(), script);
+    }
   }
 
   script = fs.realpathSync(require.resolve(script));

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "eyes": "0.1.x",
     "request": "2.9.x",
-    "vows": "0.6.x"
+    "vows": "0.7.x"
   },
   "engines": {
     "node": ">= 0.8.0"

--- a/test/fixtures/checkchildargs.js
+++ b/test/fixtures/checkchildargs.js
@@ -4,4 +4,7 @@
  */
 
 console.log('%j', process.argv);
-process.exit(0);
+
+// no need to call process.exit().
+// Prevents stdout from being sent before exit
+// especially on win32

--- a/test/simple/child-argument-test.js
+++ b/test/simple/child-argument-test.js
@@ -7,31 +7,32 @@
  */
 
 var assert = require('assert'),
-    path = require('path'),
-    spawn = require('child_process').spawn,
-    vows = require('vows'),
-    helper = require('../helper/macros.js'),
-    carapace = require('../../lib/carapace');
+  path = require('path'),
+  spawn = require('child_process').spawn,
+  vows = require('vows'),
+  helper = require('../helper/macros.js'),
+  carapace = require('../../lib/carapace');
 
 var script = path.join(__dirname, '..', 'fixtures' ,'checkchildargs.js'),
-    testPort = 8000,
-    checkargs = ['argument', '-a', 'aargument', '--test', 'testargument'];
-    argv = [script];
+  testPort = 8000,
+  checkargs = ['argument', '-a', 'aargument', '--test', 'testargument'],
+  args = [carapace.bin, script];
 
 vows.describe('carapace/simple/child-argument').addBatch({
   "When using haibu-carapace": {
     "spawning the checkchildargs.js script via the child carapace": {
       topic: function () {
         var that = this,
-            child,
-            result;
-            
+          child,
+          result;
+
         result = {
           arguments: '',
           exitCode: -1
         };
-        
-        child = spawn(carapace.bin, argv.concat(checkargs));
+
+        // Note: windows needs the path to node for spawn to work!!
+        child = spawn(process.execPath, args.concat(checkargs));
 
         child.stdout.on('data', function (data) {
           result.arguments += data;
@@ -39,7 +40,6 @@ vows.describe('carapace/simple/child-argument').addBatch({
 
         child.on('exit', function (code) {
           result.exitCode = code;
-
           //
           // Process all events before asserting
           //
@@ -56,15 +56,19 @@ vows.describe('carapace/simple/child-argument').addBatch({
           assert.equal(info.exitCode, 0);
         },
         "and correct client arguments": function (_, info, child) {
+
           var childargs = JSON.parse(info.arguments),
-              resultScript,
-              node,
-              
+            resultScript,
+            node,
+
           //
           // First two are reference to node and the script itself
           //
-          node = childargs.splice(0, 1);
+            node = childargs.splice(0, 1);
+
+
           resultScript = childargs.splice(0, 1);
+
           assert.equal(resultScript, script);
           assert.deepEqual(childargs, checkargs);
         }


### PR DESCRIPTION
The windows-fix branch makes a few changes to allow haibu-carapace to run on windows. The following changes were made:
1. bumped vows dependency to version 0.7.x so npm test will run on windows.
2. fixed example spawner.js to set carapace.script to the script. carapace.run() will not work unless this is set. example seems out of sync with how carapace.run() is currently implemented.
3. fixed carapace checks for absolute paths so they also work on windows.
4. changes calls to spawn() to use process.execPath as the cmd arg. win32 needs the path to node in order to spawn a script.
5. removed test for port 1024 from test/net/errors-test.js (win32 only) as windows will allow non-root access to ports less than 1024, including port 80.
6. removed process.exit(0) from test\fixtures\checkchildargs.js. process.exit() was terminating process before data from console.log could be sent to stdout.
7. added .idea/ to .gitignore to ignore Webstorm IDE files.

All npm tests pass on windows/mac/linux
